### PR TITLE
add initial unit tests for BiniBFT parsing

### DIFF
--- a/request_inspector_test.go
+++ b/request_inspector_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	bft "github.com/hyperledger/binibft-poc/consensus/pkg/types"
+)
+
+func TestRequestID(t *testing.T) {
+	node := &Node{}
+	tests := []struct {
+		name     string
+		input    Transaction
+		expected bft.RequestInfo
+	}{
+		{
+			name: "extract request info from simple transaction",
+			input: Transaction{
+				ClientID: "client-1",
+				TS:       10,
+				ID:       "tx-10",
+				Data:     "payload",
+			},
+			expected: bft.RequestInfo{ClientID: "client-1", ID: "tx-10"},
+		},
+		{
+			name: "extract request info from different client",
+			input: Transaction{
+				ClientID: "client-2",
+				TS:       20,
+				ID:       "tx-20",
+				Data:     "payload-2",
+			},
+			expected: bft.RequestInfo{ClientID: "client-2", ID: "tx-20"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := node.RequestID(tt.input.ToBytes())
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Fatalf("request info mismatch: got %+v want %+v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTransactionRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		txn  Transaction
+	}{
+		{
+			name: "simple transaction",
+			txn: Transaction{
+				ClientID: "client-1",
+				TS:       1,
+				ID:       "tx-1",
+				Data:     "payload-a",
+			},
+		},
+		{
+			name: "transaction with larger payload",
+			txn: Transaction{
+				ClientID: "client-2",
+				TS:       42,
+				ID:       "tx-2",
+				Data:     "payload-with-more-content",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TransactionFromBytes(tt.txn.ToBytes())
+			if !reflect.DeepEqual(*got, tt.txn) {
+				t.Fatalf("round-trip mismatch: got %+v want %+v", *got, tt.txn)
+			}
+		})
+	}
+}
+
+func TestBlockDataRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		block BlockData
+	}{
+		{
+			name:  "empty transactions",
+			block: BlockData{Transactions: [][]byte{}},
+		},
+		{
+			name: "multiple transactions",
+			block: BlockData{Transactions: [][]byte{
+				Transaction{ClientID: "c1", TS: 1, ID: "t1", Data: "a"}.ToBytes(),
+				Transaction{ClientID: "c2", TS: 2, ID: "t2", Data: "b"}.ToBytes(),
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BlockDataFromBytes(tt.block.ToBytes())
+			if !reflect.DeepEqual(*got, tt.block) {
+				t.Fatalf("round-trip mismatch: got %+v want %+v", *got, tt.block)
+			}
+		})
+	}
+}
+
+func TestBlockHeaderRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		header BlockHeader
+	}{
+		{
+			name: "first sequence",
+			header: BlockHeader{
+				Sequence: 1,
+				PrevHash: "prev-hash-1",
+				DataHash: "data-hash-1",
+			},
+		},
+		{
+			name: "later sequence",
+			header: BlockHeader{
+				Sequence: 99,
+				PrevHash: "prev-hash-98",
+				DataHash: "data-hash-99",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BlockHeaderFromBytes(tt.header.ToBytes())
+			if !reflect.DeepEqual(*got, tt.header) {
+				t.Fatalf("round-trip mismatch: got %+v want %+v", *got, tt.header)
+			}
+		})
+	}
+}
+
+func TestBlockRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		block Block
+	}{
+		{
+			name: "empty block",
+			block: Block{
+				Sequence:     1,
+				PrevHash:     "genesis",
+				Metadata:     []byte{},
+				Transactions: []Transaction{},
+			},
+		},
+		{
+			name: "block with transactions",
+			block: Block{
+				Sequence: 2,
+				PrevHash: "hash-1",
+				Metadata: []byte{1, 2, 3},
+				Transactions: []Transaction{
+					{ClientID: "c1", TS: 10, ID: "t10", Data: "d10"},
+					{ClientID: "c2", TS: 11, ID: "t11", Data: "d11"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BlockFromBytes(tt.block.ToBytes())
+			if !reflect.DeepEqual(*got, tt.block) {
+				t.Fatalf("round-trip mismatch: got %+v want %+v", *got, tt.block)
+			}
+		})
+	}
+}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	bft "github.com/hyperledger/binibft-poc/consensus/pkg/types"
+)
+
+func TestVerifyProposal(t *testing.T) {
+	node := &Node{}
+	tests := []struct {
+		name     string
+		payload  BlockData
+		expected []bft.RequestInfo
+	}{
+		{
+			name:     "empty proposal payload",
+			payload:  BlockData{Transactions: [][]byte{}},
+			expected: []bft.RequestInfo{},
+		},
+		{
+			name: "proposal with multiple transactions",
+			payload: BlockData{Transactions: [][]byte{
+				Transaction{ClientID: "client-a", TS: 1, ID: "tx-a", Data: "alpha"}.ToBytes(),
+				Transaction{ClientID: "client-b", TS: 2, ID: "tx-b", Data: "beta"}.ToBytes(),
+			}},
+			expected: []bft.RequestInfo{
+				{ClientID: "client-a", ID: "tx-a"},
+				{ClientID: "client-b", ID: "tx-b"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proposal := bft.Proposal{Payload: tt.payload.ToBytes()}
+			got, err := node.VerifyProposal(proposal)
+			if err != nil {
+				t.Fatalf("VerifyProposal returned error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Fatalf("request info mismatch: got %+v want %+v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRequestsFromProposal(t *testing.T) {
+	node := &Node{}
+	tests := []struct {
+		name     string
+		payload  BlockData
+		expected []bft.RequestInfo
+	}{
+		{
+			name:     "empty proposal payload",
+			payload:  BlockData{Transactions: [][]byte{}},
+			expected: []bft.RequestInfo{},
+		},
+		{
+			name: "proposal with one transaction",
+			payload: BlockData{Transactions: [][]byte{
+				Transaction{ClientID: "client-z", TS: 7, ID: "tx-z", Data: "zeta"}.ToBytes(),
+			}},
+			expected: []bft.RequestInfo{
+				{ClientID: "client-z", ID: "tx-z"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proposal := bft.Proposal{Payload: tt.payload.ToBytes()}
+			got := node.RequestsFromProposal(proposal)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Fatalf("request info mismatch: got %+v want %+v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add initial unit tests for serialization round-trip helpers in `types.go`
- add verifier path tests for `VerifyProposal` and `RequestsFromProposal`
- add request inspector tests for `RequestID`
- keep scope tests-only with no production behavior changes

This is a issue contribution aligned with mentorship issue #79:
https://github.com/LF-Decentralized-Trust-Mentorships/mentorship-program/issues/79

It adds foundational test coverage for core proposal/request parsing logic on the `binibft` branch.

## Testing
- Added table-driven test cases (at least 2 per function group)
- `go test ./...` should be run in an environment with Go installed