### PR TITLE
test: Add Initial Unit Tests for BiniBFT Proposal and Request Parsing

### DIFF
--- a/request_inspector_test.go
+++ b/request_inspector_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	bft "github.com/hyperledger/binibft-poc/consensus/pkg/types"
+)
+
+func TestRequestID(t *testing.T) {
+	node := &Node{}
+
+	tests := []struct {
+		name string
+		req  []byte
+		want bft.RequestInfo
+	}{
+		{
+			name: "Case 1: Valid transaction bytes",
+			req: Transaction{
+				ClientID: "client-A",
+				ID:       "id-A",
+			}.ToBytes(),
+			want: bft.RequestInfo{
+				ClientID: "client-A",
+				ID:       "id-A",
+			},
+		},
+		{
+			name: "Case 2: Valid transaction bytes with empty strings",
+			req: Transaction{
+				ClientID: "",
+				ID:       "",
+			}.ToBytes(),
+			want: bft.RequestInfo{
+				ClientID: "",
+				ID:       "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := node.RequestID(tt.req)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Node.RequestID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTransaction_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		txn  Transaction
+	}{
+		{
+			name: "Case 1: Standard transaction",
+			txn: Transaction{
+				ClientID: "client-1",
+				TS:       1234567890,
+				ID:       "txn-1",
+				Data:     "data-1",
+			},
+		},
+		{
+			name: "Case 2: Empty fields transaction",
+			txn: Transaction{
+				ClientID: "",
+				TS:       0,
+				ID:       "",
+				Data:     "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytes := tt.txn.ToBytes()
+			decoded := TransactionFromBytes(bytes)
+			if !reflect.DeepEqual(&tt.txn, decoded) {
+				t.Errorf("Transaction round trip failed: got %v, want %v", decoded, &tt.txn)
+			}
+		})
+	}
+}
+
+func TestBlockData_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		data BlockData
+	}{
+		{
+			name: "Case 1: With transactions",
+			data: BlockData{
+				Transactions: [][]byte{
+					[]byte("tx1"),
+					[]byte("tx2"),
+				},
+			},
+		},
+		{
+			name: "Case 2: Empty transactions",
+			data: BlockData{
+				Transactions: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytes := tt.data.ToBytes()
+			decoded := BlockDataFromBytes(bytes)
+
+			if len(tt.data.Transactions) == 0 && len(decoded.Transactions) == 0 {
+				tt.data.Transactions = nil
+				decoded.Transactions = nil
+			}
+
+			if !reflect.DeepEqual(&tt.data, decoded) {
+				t.Errorf("BlockData round trip failed: got %v, want %v", decoded, &tt.data)
+			}
+		})
+	}
+}
+
+func TestBlockHeader_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		header BlockHeader
+	}{
+		{
+			name: "Case 1: Standard block header",
+			header: BlockHeader{
+				Sequence: 1,
+				PrevHash: "prev-hash-1",
+				DataHash: "data-hash-1",
+			},
+		},
+		{
+			name: "Case 2: Empty block header",
+			header: BlockHeader{
+				Sequence: 0,
+				PrevHash: "",
+				DataHash: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytes := tt.header.ToBytes()
+			decoded := BlockHeaderFromBytes(bytes)
+			if !reflect.DeepEqual(&tt.header, decoded) {
+				t.Errorf("BlockHeader round trip failed: got %v, want %v", decoded, &tt.header)
+			}
+		})
+	}
+}
+
+func TestBlock_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		block Block
+	}{
+		{
+			name: "Case 1: Standard block",
+			block: Block{
+				Sequence: 1,
+				PrevHash: "prev-hash",
+				Metadata: []byte("meta"),
+				Transactions: []Transaction{
+					{ClientID: "client1", TS: 1, ID: "1", Data: "data1"},
+				},
+			},
+		},
+		{
+			name: "Case 2: Empty block",
+			block: Block{
+				Sequence:     0,
+				PrevHash:     "",
+				Metadata:     nil,
+				Transactions: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytes := tt.block.ToBytes()
+			decoded := BlockFromBytes(bytes)
+
+			if len(tt.block.Metadata) == 0 && len(decoded.Metadata) == 0 {
+				tt.block.Metadata = nil
+				decoded.Metadata = nil
+			}
+			if len(tt.block.Transactions) == 0 && len(decoded.Transactions) == 0 {
+				tt.block.Transactions = nil
+				decoded.Transactions = nil
+			}
+
+			if !reflect.DeepEqual(&tt.block, decoded) {
+				t.Errorf("Block round trip failed: got %v, want %v", decoded, &tt.block)
+			}
+		})
+	}
+}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	bft "github.com/hyperledger/binibft-poc/consensus/pkg/types"
+)
+
+func TestVerifyProposal(t *testing.T) {
+	node := &Node{}
+
+	tx1 := Transaction{ClientID: "client-1", ID: "tx-1"}
+	tx2 := Transaction{ClientID: "client-2", ID: "tx-2"}
+
+	blockData1 := BlockData{
+		Transactions: [][]byte{tx1.ToBytes(), tx2.ToBytes()},
+	}
+
+	emptyBlockData := BlockData{Transactions: [][]byte{}}
+
+	tests := []struct {
+		name     string
+		proposal bft.Proposal
+		want     []bft.RequestInfo
+		wantErr  bool
+	}{
+		{
+			name: "Case 1: Proposal with multiple transactions",
+			proposal: bft.Proposal{
+				Payload: blockData1.ToBytes(),
+			},
+			want: []bft.RequestInfo{
+				{ClientID: "client-1", ID: "tx-1"},
+				{ClientID: "client-2", ID: "tx-2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case 2: Proposal with no transactions",
+			proposal: bft.Proposal{
+				Payload: emptyBlockData.ToBytes(),
+			},
+			want:    []bft.RequestInfo{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := node.VerifyProposal(tt.proposal)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Node.VerifyProposal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Node.VerifyProposal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestsFromProposal(t *testing.T) {
+	node := &Node{}
+
+	tx1 := Transaction{ClientID: "client-3", ID: "tx-3"}
+
+	blockData1 := BlockData{
+		Transactions: [][]byte{tx1.ToBytes()},
+	}
+
+	emptyBlockData := BlockData{Transactions: [][]byte{}}
+
+	tests := []struct {
+		name     string
+		proposal bft.Proposal
+		want     []bft.RequestInfo
+	}{
+		{
+			name: "Case 1: Proposal with one transaction",
+			proposal: bft.Proposal{
+				Payload: blockData1.ToBytes(),
+			},
+			want: []bft.RequestInfo{
+				{ClientID: "client-3", ID: "tx-3"},
+			},
+		},
+		{
+			name: "Case 2: Empty proposal payload",
+			proposal: bft.Proposal{
+				Payload: emptyBlockData.ToBytes(),
+			},
+			want: []bft.RequestInfo{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := node.RequestsFromProposal(tt.proposal)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Node.RequestsFromProposal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
This PR introduces the initial set of unit tests for the BiniBFT proposal and request parsing logic on the `binibft` branch, fulfilling the requirements for Issue #16. No production behavior or implementation details have been modified.

### Changes Included
- **`types_test.go`**: Added table-driven round-trip tests (serialization and deserialization) for `Transaction`, `BlockData`, `BlockHeader`, and `Block`. Handled standard and edge cases (e.g., empty fields).
- **`verifier_test.go`**: Implemented table-driven tests for `VerifyProposal` and `RequestsFromProposal` to ensure they accurately extract the expected `RequestInfo` lists from valid block payloads.
- **`request_inspector_test.go`**: Added table-driven tests for `RequestID` to verify the correct extraction of `ClientID` and `ID` from serialized transactions.

### Related Issues
- Resolves #16 
- Reference: LF-Decentralized-Trust-Mentorships/mentorship-program#79

### Acceptance Criteria Met
- [x] New tests added and pass locally with `go test ./...` on `binibft`.
- [x] Tests are table-driven covering at least 2 cases per function group.
- [x] No production behavior changes included (tests-only).
- [x] Commits are signed off (`-s`) following standard Hyperledger contribution guidelines.
