### PR TITLE
Modernize sort functions

### DIFF
--- a/consensus/internal/bft/util.go
+++ b/consensus/internal/bft/util.go
@@ -12,14 +12,14 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
 
+	protos "github.com/hyperledger/binibft-poc/consensus/binibftprotos"
 	"github.com/hyperledger/binibft-poc/consensus/pkg/api"
 	"github.com/hyperledger/binibft-poc/consensus/pkg/types"
-	protos "github.com/hyperledger/binibft-poc/consensus/binibftprotos"
 
 	"github.com/golang/protobuf/proto"
 )
@@ -185,7 +185,7 @@ func ComputeHierarchy(N, v int) (primary int, secondaries []int, followersOf map
 			followersSet = append(followersSet, n)
 		}
 	}
-	sort.Ints(followersSet)
+	slices.Sort(followersSet)
 	F := len(followersSet)
 	q := F / S
 	r := F % S

--- a/consensus/pkg/api/metrics.go
+++ b/consensus/pkg/api/metrics.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/hyperledger/binibft-poc/consensus/pkg/metrics"
@@ -51,7 +51,7 @@ func NewHistogramOpts(old metrics.HistogramOpts, labelNames []string) metrics.Hi
 }
 
 func makeStatsdFormat(labelNames []string, str string) string {
-	sort.Strings(labelNames)
+	slices.Sort(labelNames)
 	for _, s := range labelNames {
 		str += fmt.Sprintf(".%%{%s}", s)
 	}
@@ -62,7 +62,7 @@ func makeStatsdFormat(labelNames []string, str string) string {
 func makeLabelNames(labelNames []string, names ...string) []string {
 	ln := make([]string, 0, len(names)+len(labelNames))
 	ln = append(ln, names...)
-	sort.Strings(labelNames)
+	slices.Sort(labelNames)
 	ln = append(ln, labelNames...)
 	return ln
 }

--- a/consensus/pkg/consensus/consensus.go
+++ b/consensus/pkg/consensus/consensus.go
@@ -6,17 +6,17 @@
 package consensus
 
 import (
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	protos "github.com/hyperledger/binibft-poc/consensus/binibftprotos"
 	algorithm "github.com/hyperledger/binibft-poc/consensus/internal/bft"
 	bft "github.com/hyperledger/binibft-poc/consensus/pkg/api"
 	"github.com/hyperledger/binibft-poc/consensus/pkg/metrics/disabled"
 	"github.com/hyperledger/binibft-poc/consensus/pkg/types"
-	protos "github.com/hyperledger/binibft-poc/consensus/binibftprotos"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
@@ -377,9 +377,7 @@ func (c *Consensus) setNodes(nodes []uint64) {
 func sortNodes(nodes []uint64) []uint64 {
 	sorted := make([]uint64, len(nodes))
 	copy(sorted, nodes)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i] < sorted[j]
-	})
+	slices.Sort(sorted)
 	return sorted
 }
 

--- a/consensus/pkg/wal/util.go
+++ b/consensus/pkg/wal/util.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hyperledger/binibft-poc/consensus/pkg/api"
@@ -78,7 +78,7 @@ func dirReadWalNames(dirPath string) ([]string, error) {
 		}
 	}
 
-	sort.Strings(walNames)
+	slices.Sort(walNames)
 
 	return walNames, nil
 }
@@ -86,7 +86,7 @@ func dirReadWalNames(dirPath string) ([]string, error) {
 // checkWalFiles for continuous sequence, readable CRC-Anchor.
 // If the last file cannot be read, it may be ignored,  (or repaired).
 func checkWalFiles(logger api.Logger, dirName string, walNames []string) ([]uint64, error) {
-	sort.Strings(walNames)
+	slices.Sort(walNames)
 
 	indexes := make([]uint64, 0)
 
@@ -131,13 +131,8 @@ func checkWalFiles(logger api.Logger, dirName string, walNames []string) ([]uint
 			return nil, errors.New("wal: files not in sequence")
 		}
 	}
-
-	sort.Slice(indexes,
-		func(i, j int) bool {
-			return indexes[i] < indexes[j]
-		},
-	)
-
+	
+	slices.Sort(indexes)
 	return indexes, nil
 }
 


### PR DESCRIPTION
# Refactor: replace deprecated `sort` package calls with `slices` package equivalents

## Summary

This PR modernises the sorting idioms used across the consensus library by replacing uses of the legacy `sort` package with the type-safe, generic `slices` package introduced in Go 1.21. The module's `go.mod` already declares `go 1.21`, so no minimum-version bump is required.

Code that previously called `sort.Slice`, `sort.Strings`, or `sort.Ints` have been replaced with the equivalent `slices.Sort` call. In each case the semantics are identical — ascending natural order — so there is no behavioural change.

---

## Motivation

The `sort` package predates Go generics and requires either a concrete typed helper (`sort.Ints`, `sort.Strings`) or a hand-written comparator closure passed to `sort.Slice`. Both approaches are now considered legacy style.

The `slices` package (stdlib since Go 1.21) provides `slices.Sort[S ~[]E, E cmp.Ordered]`, which is generic, avoids the closure overhead, and is more readable.

---

## Changes

### `consensus/internal/bft/util.go`
- **Line 188** — `sort.Ints(followersSet)` → `slices.Sort(followersSet)`  
  Sorts the integer slice of follower node IDs inside `ComputeHierarchy`.

### `consensus/pkg/wal/util.go`
- **Line 81** — `sort.Strings(walNames)` → `slices.Sort(walNames)`  
  Sorts WAL file names after suffix filtering in `dirReadWalNames`.
- **Line 89** — `sort.Strings(walNames)` → `slices.Sort(walNames)`  
  Sorts WAL file names at the beginning of `checkWalFiles` to enforce ordering before iteration.
- **Lines 135–139** — multi-line `sort.Slice(indexes, func(i, j int) bool { return indexes[i] < indexes[j] })` → `slices.Sort(indexes)`  
  Sorts the collected `uint64` WAL index values at the end of `checkWalFiles`. The comparator closure is eliminated entirely.

### `consensus/pkg/consensus/consensus.go`
- **Lines 380–384** — multi-line `sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })` → `slices.Sort(sorted)`  
  Sorts a copy of the node ID slice in the `sortNodes` helper. The comparator closure is eliminated entirely.

### `consensus/pkg/api/metrics.go`
- **Line 54** — `sort.Strings(labelNames)` → `slices.Sort(labelNames)`  
  Sorts metric label names in `makeStatsdFormat` before building the statsd format string.
- **Line 65** — `sort.Strings(labelNames)` → `slices.Sort(labelNames)`  
  Sorts metric label names in `makeLabelNames` before appending them to the result slice.

### Import cleanup
In each of the four affected files the `"sort"` import was replaced with `"slices"`.

---

## Testing

No test changes are required. The replacement is a mechanical substitution with identical runtime semantics. Existing unit and integration tests continue to exercise the same code paths and provide the same coverage.

---
