### PR TITLE
Fix Paxos proposer busy loop, livelock and make tests deterministic

### DIFF
--- a/candidates/siddhantprateek/paxos/main.go
+++ b/candidates/siddhantprateek/paxos/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"sync"
+	"time"
 )
 
 type Proposal struct {
@@ -21,6 +22,7 @@ type Learner struct {
 	mu         sync.Mutex
 	accepted   []Proposal
 	quorumSize int
+	decided    chan struct{} // Channel to notify when decided
 }
 
 type Proposer struct {
@@ -29,6 +31,7 @@ type Proposer struct {
 	value       interface{}
 	acceptors   []*Acceptor
 	learners    []*Learner
+	stop        chan struct{} // Channel to stop proposing
 }
 
 func NewAcceptor() *Acceptor {
@@ -36,7 +39,10 @@ func NewAcceptor() *Acceptor {
 }
 
 func NewLearner(quorumSize int) *Learner {
-	return &Learner{quorumSize: quorumSize}
+	return &Learner{
+		quorumSize: quorumSize,
+		decided:    make(chan struct{}),
+	}
 }
 
 func NewProposer(proposalNum int, value interface{}, acceptors []*Acceptor, learners []*Learner) *Proposer {
@@ -45,6 +51,18 @@ func NewProposer(proposalNum int, value interface{}, acceptors []*Acceptor, lear
 		value:       value,
 		acceptors:   acceptors,
 		learners:    learners,
+		stop:        make(chan struct{}),
+	}
+}
+
+func (p *Proposer) Stop() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	select {
+	case <-p.stop:
+		// Already stopped
+	default:
+		close(p.stop)
 	}
 }
 
@@ -74,14 +92,25 @@ func (l *Learner) ReceiveAccepted(prop Proposal) bool {
 	defer l.mu.Unlock()
 	l.accepted = append(l.accepted, prop)
 	if len(l.accepted) >= l.quorumSize {
+		select {
+		case <-l.decided:
+			// Already closed
+		default:
+			close(l.decided)
+		}
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 func (p *Proposer) Propose() {
 	for {
+		select {
+		case <-p.stop:
+			return
+		default:
+		}
+
 		p.mu.Lock()
 		n := p.proposalNum
 		p.mu.Unlock()
@@ -109,6 +138,8 @@ func (p *Proposer) Propose() {
 				p.mu.Lock()
 				p.proposalNum++
 				p.mu.Unlock()
+				// Wait/backoff briefly before next proposal round to reduce contention
+				time.Sleep(10 * time.Millisecond)
 			} else {
 				p.mu.Lock()
 				p.proposalNum++
@@ -127,8 +158,20 @@ func (p *Proposer) Propose() {
 					for _, learner := range p.learners {
 						learner.ReceiveAccepted(Proposal{Number: n, Value: p.value, Decided: true})
 					}
+					// Consensus has been reached successfully, terminate proposal loop.
+					return
+				} else {
+					// Failed accept phase: backoff briefly
+					time.Sleep(10 * time.Millisecond)
 				}
 			}
+		} else {
+			// Prepare phase failed to reach quorum.
+			// Increment proposal number to prepare for next round and sleep to avoid busy spin.
+			p.mu.Lock()
+			p.proposalNum++
+			p.mu.Unlock()
+			time.Sleep(10 * time.Millisecond)
 		}
 	}
 }

--- a/candidates/siddhantprateek/paxos/main_test.go
+++ b/candidates/siddhantprateek/paxos/main_test.go
@@ -21,12 +21,28 @@ func TestPaxosConsensus(t *testing.T) {
 		learners[i] = NewLearner(numAcceptors/2 + 1)
 	}
 
+	proposers := make([]*Proposer, numProposers)
 	for i := 0; i < numProposers; i++ {
-		proposer := NewProposer(i, fmt.Sprintf("Value from Proposer %d", i), acceptors, learners)
-		go proposer.Propose()
+		// Initialize proposers starting at proposalNum >= 1 to exceed acceptor's promisedNum (0)
+		proposers[i] = NewProposer(i+1, fmt.Sprintf("Value from Proposer %d", i), acceptors, learners)
+		go proposers[i].Propose()
 	}
 
-	time.Sleep(1 * time.Second)
+	// Wait for all learners to decide using event channel with a timeout
+	for i, learner := range learners {
+		select {
+		case <-learner.decided:
+			// Consensus reached for this learner
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Timeout waiting for learner %d to decide", i)
+		}
+	}
+
+	// Clean up proposers
+	for _, proposer := range proposers {
+		proposer.Stop()
+	}
+
 	for _, learner := range learners {
 		if len(learner.accepted) == 0 {
 			t.Errorf("Learner did not receive any accepted proposals.")
@@ -42,10 +58,19 @@ func TestPaxosConsensus(t *testing.T) {
 func TestPaxosProposer(t *testing.T) {
 	acceptor := NewAcceptor()
 	learner := NewLearner(1)
-	proposer := NewProposer(0, "Test Value", []*Acceptor{acceptor}, []*Learner{learner})
+	// Proposer proposalNum must start at >= 1 to be accepted by the acceptor (promisedNum starts at 0)
+	proposer := NewProposer(1, "Test Value", []*Acceptor{acceptor}, []*Learner{learner})
 
 	go proposer.Propose()
-	time.Sleep(100 * time.Millisecond)
+	defer proposer.Stop()
+
+	// Wait for learner to decide
+	select {
+	case <-learner.decided:
+		// Decided successfully
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Timeout waiting for learner to decide")
+	}
 
 	if len(learner.accepted) != 1 {
 		t.Errorf("Learner did not receive the accepted proposal.")


### PR DESCRIPTION
Issue 1: Livelock, CPU Busy Loop and Infinite Proposing in Paxos Implementation
Issue Description
Title: Bug: Proposer enters CPU busy loop on prepare rejection and lacks termination mechanism

Description: The current Paxos Proposer implementation in candidates/siddhantprateek/paxos/main.go has multiple issues causing high CPU utilization, infinite execution, and test flakiness:

Busy Loop on Rejection: If the proposer fails to obtain a prepare quorum (e.g. prepareResponsesCount < quorum), the loop immediately runs again with the same proposalNum. Because the proposal number is not incremented and there is no backoff sleep, the proposer tightly loops forever, consuming 100% of a CPU core.
Infinite Proposing: Once consensus is successfully reached and learners are notified of the decided value, the Proposer continues looping and proposing higher numbers infinitely without ever terminating.
Flaky and Arbitrary Test Sleep: The tests in candidates/siddhantprateek/paxos/main_test.go rely on arbitrary time.Sleep calls (e.g. 1 second and 100 milliseconds) for coordination, which is brittle, slow, and prone to flakiness under resource-constrained runners.
Proposer Stuck at proposalNum = 0: In TestPaxosProposer, the proposer is initialized with proposalNum = 0. Since the acceptor's promisedNum is initialized to 0 (the default struct value), the check n > a.promisedNum (0 > 0) is false, causing the proposer to get stuck on the first step forever.
Expected Behavior:

Proposers should back off briefly (e.g., sleep 10ms) when failing to get a quorum or failing the accept phase to prevent CPU busy loops.
Proposers should increment their proposal number on prepare failure to ensure progress in subsequent rounds.
Proposers should terminate once consensus has been decided.
Tests should use event-driven channels (decided channel in Learners) for deterministic and fast execution.
Proposers in tests should start with proposalNum >= 1.
Pull Request Description
Title: Fix Paxos proposer busy loop, livelock, and make tests deterministic

Branch: paxos-livelock-fix

Description of Changes:

Termination & Backoff: Added a stop channel to Proposer and implemented Stop(). Added time.Sleep(10 * time.Millisecond) backoffs in the Propose() loop when failing to reach prepare/accept quorums.
Progress Guarantee: Incremented the proposalNum when the prepare phase fails to obtain a quorum, ensuring subsequent attempts use a higher number.
Consensus Termination: Exited the Propose() loop gracefully as soon as consensus is reached and all learners have received the decided value.
Deterministic Testing: Added a decided channel to Learner to signal when consensus has been achieved. Replaced all brittle time.Sleep calls in main_test.go with fast, event-driven channel select statements.
Fixed Proposer Initialization: Updated proposer instantiation in tests to start with proposalNum >= 1 so that the acceptor's promisedNum is exceeded on the first prepare call.